### PR TITLE
Basic 認証の導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,17 @@
 class ApplicationController < ActionController::Base
   # basic認証のための記述
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
   # 悪意のあるユーザーの入力に対してのセキュリティ対策
   protect_from_forgery with: :exception
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
+
+  # 本番環境でのみ実行するための記述
+  def production?
+    Rails.env.production?
+  end
   
   def basic_auth
     # ターミナルで設定した環境変数を使ってログインできるようにした。

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,19 @@
 class ApplicationController < ActionController::Base
+  # basic認証のための記述
+  before_action :basic_auth
   # 悪意のあるユーザーの入力に対してのセキュリティ対策
   protect_from_forgery with: :exception
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
+
+  private
+  
+  def basic_auth
+    #ユーザー名とパスワードでBasic認証ができるように設定しています。
+    authenticate_or_request_with_http_basic do |username, password|
+      username == '66_mercari_c' && password == '66c'
+    end
+  end
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,9 +9,9 @@ class ApplicationController < ActionController::Base
   private
   
   def basic_auth
-    #ユーザー名とパスワードでBasic認証ができるように設定しています。
+    # ターミナルで設定した環境変数を使ってログインできるようにした。
     authenticate_or_request_with_http_basic do |username, password|
-      username == '66_mercari_c' && password == '66c'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -60,3 +60,7 @@
 #     # password: "please use keys"
 #   }
 server '18.179.218.201', user: 'ec2-user', roles: %w{app db web}
+
+# 本番環境のみで実行するための記述
+set :rails_env, "production"
+set :unicorn_rack_env, "production"


### PR DESCRIPTION
# What
Basic認証を実装するための記述の追加

#why

サーバーと通信が可能なユーザーとパスワードをあらかじめ設定しておき、それを知っているユーザーのみがWebアプリーションを利用できるようにすることができるようにするため。